### PR TITLE
[TASK] Remove dependency to cms

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -34,9 +34,8 @@ $EM_CONF[$_EXTKEY] = array(
 	'CGLcompliance_note' => '',
 	'constraints' => array(
 		'depends' => array(
-			'cms' => '',
-			'php' => '5.0.0-0.0.0',
-			'typo3' => '6.2.0-7.0.99',
+			'php' => '5.3.0-5.6.99',
+			'typo3' => '6.2.0-7.99.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
The system extension 'cms' has been removed from code. Relying on this
dependency is not needed and adds a note to the deprecation log.

This also adds more explicit dependencies to the PHP and TYPO3 version.
