### PR TITLE
Make getPageRenderer Typo3 Version 8.4 compatible

### DIFF
--- a/Classes/Utility/T3jqueryUtility.php
+++ b/Classes/Utility/T3jqueryUtility.php
@@ -638,7 +638,7 @@ class T3jqueryUtility
     {
         if (T3jqueryUtility::getIntFromVersion(TYPO3_version) >= 4003000) {
             /** @var PageRenderer $pagerender */
-            $pagerender = $GLOBALS['TSFE']->getPageRenderer();
+            $pagerender = GeneralUtility::makeInstance(PageRenderer::class);
             if ($conf['tofooter'] == 'footer') {
                 $pagerender->addJsFooterFile($file, $conf['type'], $conf['compress'], $conf['forceOnTop'], $conf['allWrap']);
             } else {
@@ -668,7 +668,7 @@ class T3jqueryUtility
             $GLOBALS['TSFE']->inlineJS['t3jquery.jsdata.' . $name] = $block;
         } elseif (T3jqueryUtility::getIntFromVersion(TYPO3_version) >= 4003000) {
             /** @var PageRenderer $pagerender */
-            $pagerender = $GLOBALS['TSFE']->getPageRenderer();
+            $pagerender = GeneralUtility::makeInstance(PageRenderer::class);
             if ($conf['tofooter'] == 'footer') {
                 $pagerender->addJsFooterInlineCode($name, $block, $conf['compress'], $conf['forceOnTop']);
             } else {


### PR DESCRIPTION
This change should resolve the following problem.
When including js files as follow:
<f:for each="{settings.JSPaths}" as="JSPath">
	<t3jquery:addJQueryAndScript jsfile="{JSPath}"/>
</f:for>
it comes to the following error:
 Call to undefined method TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::getPageRenderer() 
The getPageRenderer function is not accessible via the following call any more
$pagerender = $GLOBALS['TSFE']->getPageRenderer();
Modyfing the call to 
$pagerender = GeneralUtility::makeInstance(PageRenderer::class);
would resolve the problem.